### PR TITLE
fix(vite): updated vite version to 4.5.1 to fix vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "Portfolio",
+  "name": "portfolio",
   "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "Portfolio",
+      "name": "portfolio",
       "version": "3.1.1",
       "dependencies": {
         "@emailjs/browser": "^3.11.0",
@@ -27,7 +27,7 @@
         "autoprefixer": "^10.4.14",
         "postcss": "^8.4.23",
         "tailwindcss": "^3.3.2",
-        "vite": "^4.3.8"
+        "vite": "^4.5.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2982,9 +2982,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
-      "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
+      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.23",
     "tailwindcss": "^3.3.2",
-    "vite": "^4.3.8"
+    "vite": "^4.5.1"
   }
 }


### PR DESCRIPTION
Vite XSS vulnerability in server.transformIndexHtml via URL payload, which will allow an attacker to XSS was fixed in vite 4.5.1 and above, so I updated it to fix this moderate vulnerability.