### PR TITLE
chore(works): removed passing unnecessary index

### DIFF
--- a/src/components/Works.jsx
+++ b/src/components/Works.jsx
@@ -8,7 +8,6 @@ import { SectionWrapper } from "../hoc";
 import { projects } from "../constants";
 
 const ProjectCard = ({
-  index,
   name,
   description,
   tags,
@@ -37,7 +36,7 @@ const ProjectCard = ({
           <img
             src={image}
             alt="project_image"
-            className="w-full h-full object-cover rounded-2xl"
+            classname="w-full h-full object-cover rounded-2xl"
           />
 
           {isPublic && !isOnline && (
@@ -150,7 +149,7 @@ const Works = () => {
 
       <div className="mt-20 flex flex-wrap gap-7 justify-center lg:justify-start">
         {projects.map((project, index) => (
-          <ProjectCard key={`project-${index}`} index={index} {...project} />
+          <ProjectCard key={`project-${index}`} {...project} />
         ))}
       </div>
     </>


### PR DESCRIPTION
the index was just passed for the old way of how animation worked. Despite the index will still be passed, it will be passed now just as key, not also as separate index-value, which was never used.